### PR TITLE
windows: update packaging artifacts for MSI and Chocolatey builds

### DIFF
--- a/platform/windows/common.cmake
+++ b/platform/windows/common.cmake
@@ -26,7 +26,7 @@ set(file_name_list
 
 foreach(directory_name ${directory_name_list})
   install(
-    DIRECTORY "${OSQUERY_DATA_PATH}/Program Files (x86)/osquery/${directory_name}"
+    DIRECTORY "${OSQUERY_DATA_PATH}/Program Files/osquery/${directory_name}"
     DESTINATION "."
     COMPONENT osquery
   )
@@ -34,14 +34,14 @@ endforeach()
 
 foreach(file_name ${file_name_list})
   install(
-    FILES "${OSQUERY_DATA_PATH}/Program Files (x86)/osquery/${file_name}"
+    FILES "${OSQUERY_DATA_PATH}/Program Files/osquery/${file_name}"
     DESTINATION "."
     COMPONENT osquery
   )
 endforeach()
 
 install(
-  FILES "${OSQUERY_DATA_PATH}/Program Files (x86)/osquery/osqueryd/osqueryd.exe"
+  FILES "${OSQUERY_DATA_PATH}/Program Files/osquery/osqueryd/osqueryd.exe"
   DESTINATION "osqueryd"
   COMPONENT osquery
 )

--- a/platform/windows/nuget.cmake
+++ b/platform/windows/nuget.cmake
@@ -7,6 +7,18 @@
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 #
 
+install(
+  DIRECTORY "${OSQUERY_DATA_PATH}/control/nupkg/tools"
+  DESTINATION "."
+  COMPONENT osquery
+)
+
+install(
+  FILES "${OSQUERY_DATA_PATH}/control/osquery.ico"
+  DESTINATION "."
+  COMPONENT osquery
+)
+
 set(CPACK_NUGET_PACKAGE_DESCRIPTION "
   osquery allows you to easily ask questions about your Linux, macOS, and
   Windows infrastructure. Whether your goal is intrusion detection, 
@@ -26,8 +38,8 @@ set(CPACK_NUGET_PACKAGE_AUTHORS "${CPACK_PACKAGE_NAME}")
 set(CPACK_NUGET_PACKAGE_TITLE "${CPACK_PACKAGE_NAME}")
 set(CPACK_NUGET_PACKAGE_OWNERS "${CPACK_PACKAGE_NAME}")
 set(CPACK_NUGET_PACKAGE_COPYRIGHT "Copyright (c) 2014-present, The osquery authors. See LICENSE.")
-set(CPACK_NUGET_PACKAGE_LICENSEURL "${OSQUERY_REPO}blob/master/LICENSE")
-set(CPACK_NUGET_PACKAGE_ICONURL "${OSQUERY_REPO}blob/master/tools/osquery.ico")
+set(CPACK_NUGET_PACKAGE_LICENSE_FILE_NAME "LICENSE.txt")
+set(CPACK_NUGET_PACKAGE_ICON "osquery.ico")
 set(CPACK_NUGET_PACKAGE_DESCRIPTION_SUMMARY "
   osquery gives you the ability to query and log things like running 
   processes, logged in users, password changes, usb devices, firewall 

--- a/platform/windows/wix.cmake
+++ b/platform/windows/wix.cmake
@@ -17,7 +17,7 @@ else()
   message(FATAL_ERROR "The OSQUERY_BITNESS variable must be set to either 32 or 64 according to the build type")
 endif()
 
-set(CPACK_WIX_PRODUCT_ICON "${OSQUERY_DATA_PATH}/control/msi/osquery.ico")
+set(CPACK_WIX_PRODUCT_ICON "${OSQUERY_DATA_PATH}/control/osquery.ico")
 set(CPACK_WIX_UPGRADE_GUID "ea6c7327-461e-4033-847c-acdf2b85dede")
 set(CPACK_WIX_PATCH_FILE "${OSQUERY_DATA_PATH}/control/msi/osquery_wix_patch.xml")
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "osquery")


### PR DESCRIPTION
## Summary:
The chocolatey validation process checks all of the XML fields for the nuget script. The osquery icon recently moved causing our validation process to fail as the iconUrl field was giving a 404. This updates our flow to the recommended local file for the osquery icon, as per the [`nuspec` docs](https://docs.microsoft.com/en-us/nuget/reference/nuspec#icon). Further, this diff grabs the `tools` and packs directories and drops them where appropriate.

## Test Plan:
* Install osquery from the upstream repo
* Generate a chocolatey package based off of this branch:
```
PS C:\Users\Nicholas\work\repos\osquery-packaging\build> cmake -DOSQUERY_DATA_PATH="C:\" -DCPACK_GENERATOR=NuGet -DOSQUERY_PACKAGE_VERSION="4.8.0" -DOSQUERY_BITNESS=64 ../
-- Selecting Windows SDK version 10.0.18362.0 to target Windows 10.0.19042.
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Users/Nicholas/work/repos/osquery-packaging/build
PS C:\Users\Nicholas\work\repos\osquery-packaging\build> cmake --build . --config Release --target package
Microsoft (R) Build Engine version 16.8.3+39993bd9d for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  CPack: Create package using NuGet
  CPack: Install projects
  CPack: - Install project: osquery [Release]
  CPack: Create package
  Attempting to build package from 'CPack.NuGet.nuspec'.
  Successfully created package 'C:\Users\Nicholas\work\repos\osquery-packaging\build\_CPack_Packages\win64\NuGet\osquery-4.8.0\osquery.4.8.0.nupkg'.
EXEC : warning : NU5110: The script file 'manage-osqueryd.ps1' is outside the 'tools' folder and hence will not be executed during installation of this package. Move it into
the 'tools' folder. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5110: The script file 'osquery_utils.ps1' is outside the 'tools' folder and hence will not be executed during installation of this package. Move it into th
e 'tools' folder. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'manage-osqueryd.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename it to ins
tall.ps1, uninstall.ps1 or init.ps1 and place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'osquery_utils.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename it to insta
ll.ps1, uninstall.ps1 or init.ps1 and place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'tools\chocolateyBeforeModify.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Ren
ame it to install.ps1, uninstall.ps1 or init.ps1 and place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'tools\chocolateyinstall.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename i
t to install.ps1, uninstall.ps1 or init.ps1 and place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'tools\chocolateyuninstall.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename
 it to install.ps1, uninstall.ps1 or init.ps1 and place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'tools\osquery_utils.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename it to
 install.ps1, uninstall.ps1 or init.ps1 and place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
  CPack: - package: C:/Users/Nicholas/work/repos/osquery-packaging/build/osquery.4.8.0.nupkg generated.
```
* Run the chocolatey package to ensure that it installs, and that our service comes online as expected.
```
PS C:\Users\Nicholas\Desktop\tmp\testplan> choco install -yf osquery -s . --version 4.8.0 --params='/InstallService'
Chocolatey v0.10.15
Installing the following packages:
osquery
By installing you accept licenses for the packages.
osquery v4.8.0 already installed. Forcing reinstall of version '4.8.0'.
 Please use upgrade if you meant to upgrade to a new version.

osquery v4.8.0 (forced)
osquery package files install completed. Performing other installation steps.
C:\Program Files\osquery\log
True
Environment Vars (like PATH) have changed. Close/reopen your shell to
 see the changes (or in powershell/cmd.exe just type `refreshenv`).
 ShimGen has successfully created a shim for osqueryi.exe
 ShimGen has successfully created a shim for osqueryd.exe
 The install of osquery was successful.
  Software install location not explicitly set, could be in package or
  default install location if installer.

Chocolatey installed 1/1 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

...

PS C:\Users\Nicholas\Desktop\tmp\testplan> & 'C:\Program Files\osquery\osqueryd\osqueryd.exe' --version
osqueryd.exe version 4.8.0-42-g8900da822-dirty

PS C:\Users\Nicholas\Desktop\tmp\testplan> Get-Service osqueryd

Status   Name               DisplayName
------   ----               -----------
Running  osqueryd           osqueryd
```
* Lastly, run the MSI installer and ensure that it works as expected:
```
PS C:\Users\Nicholas\work\repos\osquery> Get-Service osqueryd

Status   Name               DisplayName
------   ----               -----------
Running  osqueryd           osqueryd

PS C:\Users\Nicholas\work\repos\osquery> & 'C:\Program Files\osquery\osqueryd\osqueryd.exe' --version
osqueryd.exe version 4.8.0-42-g8900da822-dirty

osquery> select name,version,uninstall_string from programs where name like '%osquery%';
+---------+---------+------------------------------------------------------+
| name    | version | uninstall_string                                     |
+---------+---------+------------------------------------------------------+
| osquery | 4.8.0   | MsiExec.exe /I{63C34DB3-9D28-445F-875A-E27ADA8AEECC} |
+---------+---------+------------------------------------------------------+
```