### PR TITLE
Deprecate Facebook naming and strings within packaging

### DIFF
--- a/platform/macos/productbuild.cmake
+++ b/platform/macos/productbuild.cmake
@@ -13,8 +13,8 @@ set(CPACK_COMMAND_PKGBUILD "${CPACK_COMMAND_PRODUCTBUILD}")
 
 install(
   FILES
-    "${OSQUERY_DATA_PATH}/control/pkg/com.osquery.osqueryd.conf"
-    "${OSQUERY_DATA_PATH}/control/pkg/com.osquery.osqueryd.plist"
+    "${OSQUERY_DATA_PATH}/control/pkg/io.osquery.osqueryd.conf"
+    "${OSQUERY_DATA_PATH}/control/pkg/io.osquery.osqueryd.plist"
 
   DESTINATION
     "/private/var/osquery"

--- a/platform/macos/productbuild.cmake
+++ b/platform/macos/productbuild.cmake
@@ -13,8 +13,8 @@ set(CPACK_COMMAND_PKGBUILD "${CPACK_COMMAND_PRODUCTBUILD}")
 
 install(
   FILES
-    "${OSQUERY_DATA_PATH}/control/pkg/com.facebook.osqueryd.conf"
-    "${OSQUERY_DATA_PATH}/control/pkg/com.facebook.osqueryd.plist"
+    "${OSQUERY_DATA_PATH}/control/pkg/com.osquery.osqueryd.conf"
+    "${OSQUERY_DATA_PATH}/control/pkg/com.osquery.osqueryd.plist"
 
   DESTINATION
     "/private/var/osquery"


### PR DESCRIPTION
See the companion PR https://github.com/osquery/osquery/pull/7159.

Do not merge until ready to tag 5.0.0.