### PR TITLE
windows: bundle LICENSE file with chocolatey package

### DIFF
--- a/platform/windows/nuget.cmake
+++ b/platform/windows/nuget.cmake
@@ -19,6 +19,12 @@ install(
   COMPONENT osquery
 )
 
+install(
+  FILES "${OSQUERY_DATA_PATH}/control/LICENSE.txt"
+  DESTINATION "."
+  COMPONENT osquery
+)
+
 set(CPACK_NUGET_PACKAGE_DESCRIPTION "
   osquery allows you to easily ask questions about your Linux, macOS, and
   Windows infrastructure. Whether your goal is intrusion detection, 


### PR DESCRIPTION
## Summary

We're seeing failures of the osquery-codesign repo to build the Windows nupkg files due to it failing to find the `LICENSE.txt` file. The specific error is detailed on [Windows nuget spec](https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5030) as the license file doesn't seem to be included in the package. Sure enough, we're only setting the CPACK license file element, and not actually bringing the license along, which I believe we should be.

## Test Plan

I'm not really able to reproduce the failure on the osquery-codesign repo locally at all, but I did create the `nupkg` and verify that the license file is now included:
```
PS C:\Users\Nicholas\Downloads\tmp\testing> choco install -yf osquery -s . --version 4.9.0 --params='/InstallService'
Chocolatey v0.10.15
Installing the following packages:
osquery
By installing you accept licenses for the packages.
osquery v4.9.0 already installed. Forcing reinstall of version '4.9.0'.
 Please use upgrade if you meant to upgrade to a new version.

osquery v4.9.0 (forced)
osquery package files install completed. Performing other installation steps.
True
True
C:\Program Files\osquery\log
True
True
True
True
Environment Vars (like PATH) have changed. Close/reopen your shell to
 see the changes (or in powershell/cmd.exe just type `refreshenv`).
 ShimGen has successfully created a shim for osqueryi.exe
 ShimGen has successfully created a shim for osqueryd.exe
 The install of osquery was successful.
  Software install location not explicitly set, could be in package or
  default install location if installer.

Chocolatey installed 1/1 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

PS C:\Users\Nicholas\Downloads\tmp\testing> ls C:\ProgramData\chocolatey\lib\osquery\

    Directory: C:\ProgramData\chocolatey\lib\osquery

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----           6/15/2021 10:17 PM                certs
d----           6/15/2021 10:17 PM                osqueryd
d----           6/15/2021 10:17 PM                tools
-a---           6/15/2021 10:17 PM            373 LICENSE.txt
-a---           6/15/2021 10:17 PM           6160 manage-osqueryd.ps1
-a---           6/15/2021 10:17 PM          10617 osquery_utils.ps1
-a---           6/15/2021 10:17 PM           6381 osquery.conf
-a---           6/15/2021 10:17 PM              0 osquery.flags
-a---           6/15/2021 10:17 PM           1150 osquery.ico
-a---           6/15/2021 10:17 PM           4267 osquery.man
-a---           6/15/2021 10:17 PM       15495908 osquery.nupkg
-a---           6/15/2021 10:17 PM           1440 osquery.nuspec
-a---           6/15/2021 10:17 PM       20772864 osqueryi.exe
```
Just to be clear, this doesn't mean that we're placing the license file in `C:\Program Files`, rather it just lives with the chocolatey package data.