### PR TITLE
nupkg: use license url until GH upgrades cmake to 3.20

### DIFF
--- a/platform/windows/nuget.cmake
+++ b/platform/windows/nuget.cmake
@@ -44,7 +44,7 @@ set(CPACK_NUGET_PACKAGE_AUTHORS "${CPACK_PACKAGE_NAME}")
 set(CPACK_NUGET_PACKAGE_TITLE "${CPACK_PACKAGE_NAME}")
 set(CPACK_NUGET_PACKAGE_OWNERS "${CPACK_PACKAGE_NAME}")
 set(CPACK_NUGET_PACKAGE_COPYRIGHT "Copyright (c) 2014-present, The osquery authors. See LICENSE.")
-set(CPACK_NUGET_PACKAGE_LICENSE_FILE_NAME "LICENSE.txt")
+set(CPACK_NUGET_PACKAGE_LICENSEURL "https://raw.githubusercontent.com/osquery/osquery/master/LICENSE")
 set(CPACK_NUGET_PACKAGE_ICON "osquery.png")
 set(CPACK_NUGET_PACKAGE_DESCRIPTION_SUMMARY "
   osquery gives you the ability to query and log things like running 


### PR DESCRIPTION
## Summary
While the `licenseUrl` [tag is deprecated in cmake 3.20](https://cmake.org/cmake/help/latest/cpack_gen/nuget.html#variable:CPACK_NUGET_PACKAGE_LICENSE_FILE_NAME), GH actions only uses 3.16, and it doesn't seem that chocolatey minds us continuing to use a url for our license file. When GH upgrades to > 3.20, we can migrate to use `CPACK_NUGET_PACKAGE_LICENSE_FILE_NAME`, but until then let's leverage the License URL so we can pass the chocolatey validations

## Test Plan
* Build package and check the nuspec that we're using, it matches that of 4.8.0, which passed validation.