### PR TITLE
[macOS] fix paths for the symlinks

### DIFF
--- a/platform/macos/common.cmake
+++ b/platform/macos/common.cmake
@@ -72,7 +72,7 @@ install(
     "${CMAKE_CURRENT_BINARY_DIR}/osqueryctl"
   
   DESTINATION
-    "/opt/local/bin/"
+    "/usr/local/bin/"
   
   COMPONENT
     osquery


### PR DESCRIPTION
fixes osquery/osquery#7236

(The version number below, is just a made up one I gave when building locally)

```
➜  /tmp lsbom -s  $(pkgutil --bom osquery-6.6.7.pkg) | pbcopy
.
./opt
./opt/osquery
./opt/osquery/lib
./opt/osquery/lib/osquery.app
./opt/osquery/lib/osquery.app/Contents
./opt/osquery/lib/osquery.app/Contents/Info.plist
./opt/osquery/lib/osquery.app/Contents/MacOS
./opt/osquery/lib/osquery.app/Contents/MacOS/osqueryd
./opt/osquery/lib/osquery.app/Contents/PkgInfo
./opt/osquery/lib/osquery.app/Contents/Resources
./opt/osquery/lib/osquery.app/Contents/Resources/osqueryctl
./opt/osquery/lib/osquery.app/Contents/embedded.provisionprofile
./private
./private/var
./private/var/log
./private/var/log/osquery
./private/var/osquery
./private/var/osquery/certs
./private/var/osquery/certs/certs.pem
./private/var/osquery/io.osquery.agent.conf
./private/var/osquery/io.osquery.agent.plist
./private/var/osquery/lenses
./private/var/osquery/lenses/access.aug
./private/var/osquery/lenses/activemq_conf.aug
./private/var/osquery/lenses/activemq_xml.aug
./private/var/osquery/lenses/afs_cellalias.aug
./private/var/osquery/lenses/aliases.aug
./private/var/osquery/lenses/anacron.aug
./private/var/osquery/lenses/approx.aug
./private/var/osquery/lenses/apt_update_manager.aug
./private/var/osquery/lenses/aptcacherngsecurity.aug
./private/var/osquery/lenses/aptconf.aug
./private/var/osquery/lenses/aptpreferences.aug
./private/var/osquery/lenses/aptsources.aug
./private/var/osquery/lenses/authorized_keys.aug
./private/var/osquery/lenses/automaster.aug
./private/var/osquery/lenses/automounter.aug
./private/var/osquery/lenses/avahi.aug
./private/var/osquery/lenses/backuppchosts.aug
./private/var/osquery/lenses/bbhosts.aug
./private/var/osquery/lenses/bootconf.aug
./private/var/osquery/lenses/build.aug
./private/var/osquery/lenses/cachefilesd.aug
./private/var/osquery/lenses/carbon.aug
./private/var/osquery/lenses/ceph.aug
./private/var/osquery/lenses/cgconfig.aug
./private/var/osquery/lenses/cgrules.aug
./private/var/osquery/lenses/channels.aug
./private/var/osquery/lenses/chrony.aug
./private/var/osquery/lenses/clamav.aug
./private/var/osquery/lenses/cobblermodules.aug
./private/var/osquery/lenses/cobblersettings.aug
./private/var/osquery/lenses/collectd.aug
./private/var/osquery/lenses/cpanel.aug
./private/var/osquery/lenses/cron.aug
./private/var/osquery/lenses/cron_user.aug
./private/var/osquery/lenses/crypttab.aug
./private/var/osquery/lenses/csv.aug
./private/var/osquery/lenses/cups.aug
./private/var/osquery/lenses/cyrus_imapd.aug
./private/var/osquery/lenses/darkice.aug
./private/var/osquery/lenses/debctrl.aug
./private/var/osquery/lenses/desktop.aug
./private/var/osquery/lenses/device_map.aug
./private/var/osquery/lenses/dhclient.aug
./private/var/osquery/lenses/dhcpd.aug
./private/var/osquery/lenses/dns_zone.aug
./private/var/osquery/lenses/dnsmasq.aug
./private/var/osquery/lenses/dovecot.aug
./private/var/osquery/lenses/dpkg.aug
./private/var/osquery/lenses/dput.aug
./private/var/osquery/lenses/erlang.aug
./private/var/osquery/lenses/ethers.aug
./private/var/osquery/lenses/exports.aug
./private/var/osquery/lenses/fai_diskconfig.aug
./private/var/osquery/lenses/fonts.aug
./private/var/osquery/lenses/fstab.aug
./private/var/osquery/lenses/fuse.aug
./private/var/osquery/lenses/gdm.aug
./private/var/osquery/lenses/getcap.aug
./private/var/osquery/lenses/group.aug
./private/var/osquery/lenses/grub.aug
./private/var/osquery/lenses/gshadow.aug
./private/var/osquery/lenses/gtkbookmarks.aug
./private/var/osquery/lenses/host_conf.aug
./private/var/osquery/lenses/hostname.aug
./private/var/osquery/lenses/hosts.aug
./private/var/osquery/lenses/hosts_access.aug
./private/var/osquery/lenses/htpasswd.aug
./private/var/osquery/lenses/httpd.aug
./private/var/osquery/lenses/inetd.aug
./private/var/osquery/lenses/inifile.aug
./private/var/osquery/lenses/inittab.aug
./private/var/osquery/lenses/inputrc.aug
./private/var/osquery/lenses/interfaces.aug
./private/var/osquery/lenses/iproute2.aug
./private/var/osquery/lenses/iptables.aug
./private/var/osquery/lenses/iscsid.aug
./private/var/osquery/lenses/jaas.aug
./private/var/osquery/lenses/jettyrealm.aug
./private/var/osquery/lenses/jmxaccess.aug
./private/var/osquery/lenses/jmxpassword.aug
./private/var/osquery/lenses/json.aug
./private/var/osquery/lenses/kdump.aug
./private/var/osquery/lenses/keepalived.aug
./private/var/osquery/lenses/known_hosts.aug
./private/var/osquery/lenses/koji.aug
./private/var/osquery/lenses/krb5.aug
./private/var/osquery/lenses/ldif.aug
./private/var/osquery/lenses/ldso.aug
./private/var/osquery/lenses/lightdm.aug
./private/var/osquery/lenses/limits.aug
./private/var/osquery/lenses/login_defs.aug
./private/var/osquery/lenses/logrotate.aug
./private/var/osquery/lenses/logwatch.aug
./private/var/osquery/lenses/lokkit.aug
./private/var/osquery/lenses/lvm.aug
./private/var/osquery/lenses/mailscanner.aug
./private/var/osquery/lenses/mailscanner_rules.aug
./private/var/osquery/lenses/masterpasswd.aug
./private/var/osquery/lenses/mcollective.aug
./private/var/osquery/lenses/mdadm_conf.aug
./private/var/osquery/lenses/memcached.aug
./private/var/osquery/lenses/mke2fs.aug
./private/var/osquery/lenses/modprobe.aug
./private/var/osquery/lenses/modules.aug
./private/var/osquery/lenses/modules_conf.aug
./private/var/osquery/lenses/mongodbserver.aug
./private/var/osquery/lenses/monit.aug
./private/var/osquery/lenses/multipath.aug
./private/var/osquery/lenses/mysql.aug
./private/var/osquery/lenses/nagioscfg.aug
./private/var/osquery/lenses/nagiosobjects.aug
./private/var/osquery/lenses/netmasks.aug
./private/var/osquery/lenses/networkmanager.aug
./private/var/osquery/lenses/networks.aug
./private/var/osquery/lenses/nginx.aug
./private/var/osquery/lenses/nrpe.aug
./private/var/osquery/lenses/nslcd.aug
./private/var/osquery/lenses/nsswitch.aug
./private/var/osquery/lenses/ntp.aug
./private/var/osquery/lenses/ntpd.aug
./private/var/osquery/lenses/odbc.aug
./private/var/osquery/lenses/opendkim.aug
./private/var/osquery/lenses/openshift_config.aug
./private/var/osquery/lenses/openshift_http.aug
./private/var/osquery/lenses/openshift_quickstarts.aug
./private/var/osquery/lenses/openvpn.aug
./private/var/osquery/lenses/oz.aug
./private/var/osquery/lenses/pagekite.aug
./private/var/osquery/lenses/pam.aug
./private/var/osquery/lenses/pamconf.aug
./private/var/osquery/lenses/passwd.aug
./private/var/osquery/lenses/pbuilder.aug
./private/var/osquery/lenses/pg_hba.aug
./private/var/osquery/lenses/pgbouncer.aug
./private/var/osquery/lenses/php.aug
./private/var/osquery/lenses/phpvars.aug
./private/var/osquery/lenses/postfix_access.aug
./private/var/osquery/lenses/postfix_main.aug
./private/var/osquery/lenses/postfix_master.aug
./private/var/osquery/lenses/postfix_passwordmap.aug
./private/var/osquery/lenses/postfix_sasl_smtpd.aug
./private/var/osquery/lenses/postfix_transport.aug
./private/var/osquery/lenses/postfix_virtual.aug
./private/var/osquery/lenses/postgresql.aug
./private/var/osquery/lenses/properties.aug
./private/var/osquery/lenses/protocols.aug
./private/var/osquery/lenses/puppet.aug
./private/var/osquery/lenses/puppet_auth.aug
./private/var/osquery/lenses/puppetfile.aug
./private/var/osquery/lenses/puppetfileserver.aug
./private/var/osquery/lenses/pylonspaste.aug
./private/var/osquery/lenses/pythonpaste.aug
./private/var/osquery/lenses/qpid.aug
./private/var/osquery/lenses/quote.aug
./private/var/osquery/lenses/rabbitmq.aug
./private/var/osquery/lenses/radicale.aug
./private/var/osquery/lenses/redis.aug
./private/var/osquery/lenses/reprepro_uploaders.aug
./private/var/osquery/lenses/resolv.aug
./private/var/osquery/lenses/rhsm.aug
./private/var/osquery/lenses/rmt.aug
./private/var/osquery/lenses/rsyncd.aug
./private/var/osquery/lenses/rsyslog.aug
./private/var/osquery/lenses/rtadvd.aug
./private/var/osquery/lenses/rx.aug
./private/var/osquery/lenses/samba.aug
./private/var/osquery/lenses/schroot.aug
./private/var/osquery/lenses/securetty.aug
./private/var/osquery/lenses/sep.aug
./private/var/osquery/lenses/services.aug
./private/var/osquery/lenses/shadow.aug
./private/var/osquery/lenses/shells.aug
./private/var/osquery/lenses/shellvars.aug
./private/var/osquery/lenses/shellvars_list.aug
./private/var/osquery/lenses/simplelines.aug
./private/var/osquery/lenses/simplevars.aug
./private/var/osquery/lenses/sip_conf.aug
./private/var/osquery/lenses/slapd.aug
./private/var/osquery/lenses/smbusers.aug
./private/var/osquery/lenses/solaris_system.aug
./private/var/osquery/lenses/soma.aug
./private/var/osquery/lenses/spacevars.aug
./private/var/osquery/lenses/splunk.aug
./private/var/osquery/lenses/squid.aug
./private/var/osquery/lenses/ssh.aug
./private/var/osquery/lenses/sshd.aug
./private/var/osquery/lenses/sssd.aug
./private/var/osquery/lenses/star.aug
./private/var/osquery/lenses/stunnel.aug
./private/var/osquery/lenses/subversion.aug
./private/var/osquery/lenses/sudoers.aug
./private/var/osquery/lenses/sysconfig.aug
./private/var/osquery/lenses/sysconfig_route.aug
./private/var/osquery/lenses/sysctl.aug
./private/var/osquery/lenses/syslog.aug
./private/var/osquery/lenses/systemd.aug
./private/var/osquery/lenses/termcap.aug
./private/var/osquery/lenses/thttpd.aug
./private/var/osquery/lenses/tmpfiles.aug
./private/var/osquery/lenses/trapperkeeper.aug
./private/var/osquery/lenses/tuned.aug
./private/var/osquery/lenses/up2date.aug
./private/var/osquery/lenses/updatedb.aug
./private/var/osquery/lenses/util.aug
./private/var/osquery/lenses/vfstab.aug
./private/var/osquery/lenses/vmware_config.aug
./private/var/osquery/lenses/vsftpd.aug
./private/var/osquery/lenses/webmin.aug
./private/var/osquery/lenses/wine.aug
./private/var/osquery/lenses/xendconfsxp.aug
./private/var/osquery/lenses/xinetd.aug
./private/var/osquery/lenses/xml.aug
./private/var/osquery/lenses/xorg.aug
./private/var/osquery/lenses/xymon.aug
./private/var/osquery/lenses/xymon_alerting.aug
./private/var/osquery/lenses/yaml.aug
./private/var/osquery/lenses/yum.aug
./private/var/osquery/osquery.example.conf
./private/var/osquery/packs
./private/var/osquery/packs/hardware-monitoring.conf
./private/var/osquery/packs/incident-response.conf
./private/var/osquery/packs/it-compliance.conf
./private/var/osquery/packs/osquery-monitoring.conf
./private/var/osquery/packs/ossec-rootkit.conf
./private/var/osquery/packs/osx-attacks.conf
./private/var/osquery/packs/unwanted-chrome-extensions.conf
./private/var/osquery/packs/vuln-management.conf
./private/var/osquery/packs/windows-attacks.conf
./private/var/osquery/packs/windows-hardening.conf
./usr
./usr/local
./usr/local/bin
./usr/local/bin/osqueryctl
./usr/local/bin/osqueryi

```