### PR TITLE
Fix systemd service install path

### DIFF
--- a/platform/linux/deb.cmake
+++ b/platform/linux/deb.cmake
@@ -24,7 +24,7 @@ endif()
 
 install(
   FILES "${OSQUERY_DATA_PATH}/control/deb/lib/systemd/system/osqueryd.service"
-  DESTINATION "lib/systemd/system"
+  DESTINATION "/usr/lib/systemd/system"
   COMPONENT osquery
 )
 

--- a/platform/linux/rpm.cmake
+++ b/platform/linux/rpm.cmake
@@ -43,7 +43,7 @@ install(
 
 install(
   FILES "${OSQUERY_DATA_PATH}/control/rpm/lib/systemd/system/osqueryd.service"
-  DESTINATION "lib/systemd/system"
+  DESTINATION "/usr/lib/systemd/system"
   COMPONENT osquery
 )
 


### PR DESCRIPTION
The systemd service should be still installed under /usr,
so that it's automatically available to systemd, as before.