### PR TITLE
Fix: add symlinks in /usr for compatibility again (#17)

### DIFF
--- a/platform/linux/common.cmake
+++ b/platform/linux/common.cmake
@@ -56,17 +56,8 @@ execute_process(
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
-# Fix 🐛 add symlinks in /usr for compatibility again (#17)
 execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E create_symlink "/usr/local/bin/osqueryctl" osqueryctl
-  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-)
-execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E create_symlink "/usr/local/bin/osqueryd" osqueryd
-  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-)
-execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E create_symlink "/usr/local/bin/osqueryi" osqueryi
+  COMMAND "${CMAKE_COMMAND}" -E create_symlink "/opt/osquery/bin/osqueryd" osqueryd
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
@@ -74,12 +65,10 @@ install(
   FILES
     "${CMAKE_CURRENT_BINARY_DIR}/osqueryi"
     "${CMAKE_CURRENT_BINARY_DIR}/osqueryctl"
-    "/usr/local/bin/osqueryctl"
-    "/usr/local/bin/osqueryd"
-    "/usr/local/bin/osqueryi"
+    "${CMAKE_CURRENT_BINARY_DIR}/osqueryd"
   
   DESTINATION
-    "/usr/local/bin/"
+    "/usr/bin/"
   
   COMPONENT
     osquery

--- a/platform/linux/common.cmake
+++ b/platform/linux/common.cmake
@@ -56,10 +56,27 @@ execute_process(
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
+# Fix 🐛 add symlinks in /usr for compatibility again (#17)
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" -E create_symlink "/usr/local/bin/osqueryctl" osqueryctl
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" -E create_symlink "/usr/local/bin/osqueryd" osqueryd
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" -E create_symlink "/usr/local/bin/osqueryi" osqueryi
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
 install(
   FILES
     "${CMAKE_CURRENT_BINARY_DIR}/osqueryi"
     "${CMAKE_CURRENT_BINARY_DIR}/osqueryctl"
+    "/usr/local/bin/osqueryctl"
+    "/usr/local/bin/osqueryd"
+    "/usr/local/bin/osqueryi"
   
   DESTINATION
     "/usr/local/bin/"


### PR DESCRIPTION
This change re-introduces some symlinks in /usr that [have existed before 5.0](https://github.com/osquery/osquery-packaging/pull/13) and [are missing on some Enterprise Linux distributions](https://github.com/osquery/osquery-packaging/issues/17).
