### PR TITLE
Restore query packs in Windows packaging

### DIFF
--- a/platform/windows/common.cmake
+++ b/platform/windows/common.cmake
@@ -18,6 +18,7 @@ endif()
 
 set(directory_name_list
   "certs"
+  "packs"
   "log"
 )
 


### PR DESCRIPTION
Needed by osquery/osquery#7388