### PR TITLE
nupkg: ensure that VERIFICATION.txt is bundled with chocolatey package

### DIFF
--- a/platform/windows/nuget.cmake
+++ b/platform/windows/nuget.cmake
@@ -14,6 +14,12 @@ install(
 )
 
 install(
+  FILES "${OSQUERY_DATA_PATH}/control/nupkg/extras/VERIFICATION.txt"
+  DESTINATION "."
+  COMPONENT osquery
+)
+
+install(
   FILES "${OSQUERY_DATA_PATH}/control/osquery.png"
   DESTINATION "."
   COMPONENT osquery


### PR DESCRIPTION
## Summary:

We are currently failing chocolatey verification for the automated packages as we're not including the `verification.txt` file. This diff ensures that the file is grabbed as part of the package generation.

This addresses #16.

## Test Plan:
1. Build the osquery binaries locally, then use these changes to generate a nupkg:
```
PS C:\Users\Nicholas\work\repos\osquery-packaging\build> cmake -DOSQUERY_DATA_PATH="C:\Users\Nicholas\work\repos\osquery\build\package_data" -DCPACK_GENERATOR=NuGet -DOSQUERY_PACKAGE_VERSION="5.0.1" -DOSQUERY_BITNESS=64 ../
-- Building for: Visual Studio 16 2019
-- Selecting Windows SDK version 10.0.18362.0 to target Windows 10.0.22000.
-- The C compiler identification is MSVC 19.28.29336.0
-- The CXX compiler identification is MSVC 19.28.29336.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Users/Nicholas/work/repos/osquery-packaging/build
```

2. Ensure that the verification.txt file is present in the bundle:
```
PS C:\Users\Nicholas\work\repos\osquery-packaging\build> cmake --build . --config Release --target package
Microsoft (R) Build Engine version 16.8.3+39993bd9d for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  CPack: Create package using NuGet
  CPack: Install projects
  CPack: - Install project: osquery [Release]
  CPack: Create package
  CMake Deprecation Warning at C:/Program Files/CMake/share/cmake-3.22/Modules/Internal/CPack/CPackNuGet.cmake:141 (message):
    nuspec element `licenseUrl` is deprecated in NuGet; consider replacing
    `CPACK_NUGET_PACKAGE_LICENSEURL` with
    `CPACK_NUGET_PACKAGE_LICENSE_FILE_NAME or
    CPACK_NUGET_PACKAGE_LICENSE_EXPRESSION`
  Call Stack (most recent call first):
    C:/Program Files/CMake/share/cmake-3.22/Modules/Internal/CPack/CPackNuGet.cmake:199 (_cpack_nuget_deprecation_warning)
    C:/Program Files/CMake/share/cmake-3.22/Modules/Internal/CPack/CPackNuGet.cmake:356 (_cpack_nuget_render_spec)


  Attempting to build package from 'CPack.NuGet.nuspec'.
  Successfully created package 'C:\Users\Nicholas\work\repos\osquery-packaging\build\_CPack_Packages\win64\NuGet\osquery-5.0.1\osquery.5.0.1.nupkg'.
EXEC : warning : NU5110: The script file 'manage-osqueryd.ps1' is outside the 'tools' folder and hence will not be executed during installation of this package. Move it into the 'tools' folder. [C:\Users\Nicholas\work\
repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5110: The script file 'osquery_utils.ps1' is outside the 'tools' folder and hence will not be executed during installation of this package. Move it into the 'tools' folder. [C:\Users\Nicholas\work\re
pos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'manage-osqueryd.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename it to install.ps1, uninstall.ps1 or init.ps1 and plac
e it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'osquery_utils.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename it to install.ps1, uninstall.ps1 or init.ps1 and place
it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'tools\chocolateyBeforeModify.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename it to install.ps1, uninstall.ps1 or init
.ps1 and place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'tools\chocolateyinstall.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename it to install.ps1, uninstall.ps1 or init.ps1
and place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'tools\chocolateyuninstall.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename it to install.ps1, uninstall.ps1 or init.ps
1 and place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'tools\osquery_utils.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename it to install.ps1, uninstall.ps1 or init.ps1 and
place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
  CPack: - package: C:/Users/Nicholas/work/repos/osquery-packaging/build/osquery.5.0.1.nupkg generated.
...
PS C:\Users\Nicholas\Desktop\tmp> ls

    Directory: C:\Users\Nicholas\Desktop\tmp

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----            1/5/2022  7:30 PM                _rels
d----            1/5/2022  7:30 PM                certs
d----            1/5/2022  7:30 PM                osqueryd
d----            1/5/2022  7:30 PM                package
d----            1/5/2022  7:30 PM                packs
d----            1/5/2022  7:30 PM                tools
-----            1/5/2022  5:59 PM            909 [Content_Types].xml
-----            1/6/2022 12:14 AM            373 LICENSE.txt
-----            1/6/2022 12:14 AM           6160 manage-osqueryd.ps1
-----            1/6/2022 12:14 AM          10576 osquery_utils.ps1
-a---            1/5/2022  7:30 PM       17073990 osquery.5.0.1.nupkg
-----            1/6/2022 12:14 AM           6408 osquery.conf
-----            1/6/2022 12:14 AM              0 osquery.flags
-----            1/6/2022 12:14 AM           4267 osquery.man
-----            1/5/2022  5:59 PM           1597 osquery.nuspec
-----            1/6/2022 12:14 AM            898 osquery.png
-----            1/6/2022 12:56 AM       23357440 osqueryi.exe
-----            1/6/2022 12:14 AM            934 VERIFICATION.txt
```

3. Lastly, verify that if we use this package for isntallation, the `VERIFICATION.txt` file exists in the Chocolatey lib dirs.
```
PS C:\Users\Nicholas\Desktop\tmp> choco uninstall -yf osquery
Chocolatey v0.10.15
Uninstalling the following packages:
osquery
True
True

osquery v5.0.1 (forced)
 Skipping auto uninstaller - No registry snapshot.
 osquery has been successfully uninstalled.
Environment Vars (like PATH) have changed. Close/reopen your shell to
 see the changes (or in powershell/cmd.exe just type `refreshenv`).

Chocolatey uninstalled 1/1 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
PS C:\Users\Nicholas\Desktop\tmp> explorer.exe C:\ProgramData\
PS C:\Users\Nicholas\Desktop\tmp> choco install -yf osquery -s . --version 5.0.1 --params='/InstallService'
Chocolatey v0.10.15
Installing the following packages:
osquery
By installing you accept licenses for the packages.

osquery v5.0.1 (forced)
osquery package files install completed. Performing other installation steps.
C:\Program Files\osquery\log
True
osqueryd
PATH environment variable does not have C:\Program Files\osquery in it. Adding...
Environment Vars (like PATH) have changed. Close/reopen your shell to
 see the changes (or in powershell/cmd.exe just type `refreshenv`).
 ShimGen has successfully created a shim for osqueryi.exe
 ShimGen has successfully created a shim for osqueryd.exe
 The install of osquery was successful.
  Software install location not explicitly set, could be in package or
  default install location if installer.

Chocolatey installed 1/1 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
PS C:\Users\Nicholas\Desktop\tmp> ls C:\ProgramData\chocolatey\lib\osquery\

    Directory: C:\ProgramData\chocolatey\lib\osquery

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----            1/5/2022  7:32 PM                certs
d----            1/5/2022  7:32 PM                osqueryd
d----            1/5/2022  7:32 PM                packs
d----            1/5/2022  7:32 PM                tools
-a---            1/5/2022  7:32 PM            373 LICENSE.txt
-a---            1/5/2022  7:32 PM           6160 manage-osqueryd.ps1
-a---            1/5/2022  7:32 PM          10576 osquery_utils.ps1
-a---            1/5/2022  7:32 PM           6408 osquery.conf
-a---            1/5/2022  7:32 PM              0 osquery.flags
-a---            1/5/2022  7:32 PM           4267 osquery.man
-a---            1/5/2022  7:32 PM       17073990 osquery.nupkg
-a---            1/5/2022  7:32 PM           1535 osquery.nuspec
-a---            1/5/2022  7:32 PM            898 osquery.png
-a---            1/5/2022  7:32 PM       23357440 osqueryi.exe
-a---            1/5/2022  7:32 PM            934 VERIFICATION.txt
```