### PR TITLE
rpm: Fix installation path of SysV startup script

### DIFF
--- a/platform/linux/rpm.cmake
+++ b/platform/linux/rpm.cmake
@@ -32,7 +32,7 @@ list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
 
 install(
   FILES "${OSQUERY_DATA_PATH}/control/rpm/etc/init.d/osqueryd"
-  DESTINATION "/etc/init.d"
+  DESTINATION "/etc/rc.d/init.d"
   COMPONENT osquery
 
   PERMISSIONS


### PR DESCRIPTION
Do not use /etc/init.d for SysV init scripts for RPM-based linux distros.  The directory should be /etc/rc.d/init.d.

When using /etc/init.d and no chkconfig or initscripts packages are installed first, this package was creating /etc/init.d as a directory.  Unfortunately, if you wanted to later install a package that brought in the chkconfig package, the RPM transaction would fail because it assumes it can create a symlink in /etc/init.d when a directory already exists.

A bug was filed for this here:
https://github.com/osquery/osquery/issues/7949