### PR TITLE
Remove the need for a compiler to be present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 #
 
-project("osquery")
+project("osquery" NONE)
 cmake_minimum_required(VERSION 3.17.5)
 
 set(OSQUERY_DATA_PATH "" CACHE PATH "osquery package data")


### PR DESCRIPTION
Make so that CMake doesn't need a compiler to be present, since packaging does not require it.