### PR TITLE
Stage init.d script for conditional install on target hosts

### DIFF
--- a/platform/linux/deb.cmake
+++ b/platform/linux/deb.cmake
@@ -15,7 +15,7 @@ set(CPACK_DEBIAN_PACKAGE_PRIORITY "extra")
 set(CPACK_DEBIAN_PACKAGE_SECTION "default")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>=2.12), zlib1g")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "${CPACK_PACKAGE_HOMEPAGE_URL}")
-set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${OSQUERY_DATA_PATH}/control/deb/conffiles;${OSQUERY_DATA_PATH}/control/postinst")
+set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${OSQUERY_DATA_PATH}/control/deb/conffiles;${OSQUERY_DATA_PATH}/control/postinst;${OSQUERY_DATA_PATH}/control/deb/postrm")
 
 if(DEFINED OSQUERY_SOURCE_DIRECTORY_LIST)
   set(CPACK_DEB_COMPONENT_INSTALL ON)
@@ -30,7 +30,7 @@ install(
 
 install(
   FILES "${OSQUERY_DATA_PATH}/control/deb/etc/init.d/osqueryd"
-  DESTINATION "/etc/init.d"
+  DESTINATION "share/osquery/initd"
   COMPONENT osquery
 
   PERMISSIONS

--- a/platform/linux/rpm.cmake
+++ b/platform/linux/rpm.cmake
@@ -22,17 +22,22 @@ if(DEFINED OSQUERY_SOURCE_DIRECTORY_LIST)
   set(CPACK_RPM_DEBUGINFO_FILE_NAME "RPM-DEFAULT")
 endif()
 
+list(APPEND CPACK_RPM_USER_FILELIST
+  "%ghost /etc/init.d/osqueryd"
+)
+
 list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
   /etc/sysconfig
   /var
   /var/log
   /usr/lib/systemd
   /usr/lib/systemd/system
+  /etc/init.d
 )
 
 install(
   FILES "${OSQUERY_DATA_PATH}/control/rpm/etc/init.d/osqueryd"
-  DESTINATION "/etc/init.d"
+  DESTINATION "share/osquery/initd"
   COMPONENT osquery
 
   PERMISSIONS


### PR DESCRIPTION
Stop installing the SysV init script directly to /etc/init.d. Instead stage it to share/osquery/initd and let postinst copy it only when /etc/init.d exists on the target host. This avoids creating unwanted files on systemd-only hosts (RHEL 8+ minimal, AL2023).

This PR goes with https://github.com/osquery/osquery/pull/8857

RPM: use %ghost to track /etc/init.d/osqueryd for clean uninstall.
DEB: reference postrm from build artifacts for cleanup on removal.